### PR TITLE
Handles token limit while generating summaries

### DIFF
--- a/emergent/llms.py
+++ b/emergent/llms.py
@@ -7,11 +7,38 @@ from functools import wraps
 
 from dataclasses import dataclass, field
 from typing import Optional, List
-from tiktoken import Tokenizer, TokenizerConfig
+from tiktoken
 
-def count_tokens(text: str) -> int:
-    tokenizer = Tokenizer(TokenizerConfig())
-    return len(list(tokenizer.tokenize(text)))
+def num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301"):
+    """Returns the number of tokens used by a list of messages."""
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        print("Warning: model not found. Using cl100k_base encoding.")
+        encoding = tiktoken.get_encoding("cl100k_base")
+    if model == "gpt-3.5-turbo":
+        print("Warning: gpt-3.5-turbo may change over time. Returning num tokens assuming gpt-3.5-turbo-0301.")
+        return num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301")
+    elif model == "gpt-4":
+        print("Warning: gpt-4 may change over time. Returning num tokens assuming gpt-4-0314.")
+        return num_tokens_from_messages(messages, model="gpt-4-0314")
+    elif model == "gpt-3.5-turbo-0301":
+        tokens_per_message = 4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
+        tokens_per_name = -1  # if there's a name, the role is omitted
+    elif model == "gpt-4-0314":
+        tokens_per_message = 3
+        tokens_per_name = 1
+    else:
+        raise NotImplementedError(f"""num_tokens_from_messages() is not implemented for model {model}. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens.""")
+    num_tokens = 0
+    for message in messages:
+        num_tokens += tokens_per_message
+        for key, value in message.items():
+            num_tokens += len(encoding.encode(value))
+            if key == "name":
+                num_tokens += tokens_per_name
+    num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
+    return num_tokens
 
 def retry_with_exponential_backoff(
     func,
@@ -116,11 +143,10 @@ def chat_gpt_prompt(func):
             )
 
         # Calculate total tokens
-        total_tokens = sum(count_tokens(message["content"]) for message in messages)
-        api_overhead_tokens = 20  # Some overhead tokens for API formatting
+        total_tokens = num_tokens_from_messages(messages, model=model)
         
         # Check if total tokens for request exceeds token limit
-        if total_tokens + api_overhead_tokens > 4096:
+        if total_tokens > 4096:
             logging.warning("The number of tokens in the prompt exceeds the limit (4096 tokens). Skipping this prompt.")
             return
             

--- a/emergent/llms.py
+++ b/emergent/llms.py
@@ -3,11 +3,11 @@ import os
 import openai
 import random
 import time
+import tiktoken
 from functools import wraps
 
 from dataclasses import dataclass, field
 from typing import Optional, List
-from tiktoken
 
 def num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301"):
     """Returns the number of tokens used by a list of messages."""

--- a/emergent/utils.py
+++ b/emergent/utils.py
@@ -2,6 +2,7 @@ import sys
 import threading
 import itertools
 import time
+import tiktoken
 from colorama import init, Fore, Style
 
 init(autoreset=True)
@@ -77,3 +78,34 @@ def process_response(response):
 
         if ("}}" in token.strip()) and thinking:
             thinking = False
+
+def num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301"):
+    """Returns the number of tokens used by a list of messages."""
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        print("Warning: model not found. Using cl100k_base encoding.")
+        encoding = tiktoken.get_encoding("cl100k_base")
+    if model == "gpt-3.5-turbo":
+        print("Warning: gpt-3.5-turbo may change over time. Returning num tokens assuming gpt-3.5-turbo-0301.")
+        return num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301")
+    elif model == "gpt-4":
+        print("Warning: gpt-4 may change over time. Returning num tokens assuming gpt-4-0314.")
+        return num_tokens_from_messages(messages, model="gpt-4-0314")
+    elif model == "gpt-3.5-turbo-0301":
+        tokens_per_message = 4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
+        tokens_per_name = -1  # if there's a name, the role is omitted
+    elif model == "gpt-4-0314":
+        tokens_per_message = 3
+        tokens_per_name = 1
+    else:
+        raise NotImplementedError(f"""num_tokens_from_messages() is not implemented for model {model}. See https://github.com/openai/openai-python/blob/main/chatml.md for information on how messages are converted to tokens.""")
+    num_tokens = 0
+    for message in messages:
+        num_tokens += tokens_per_message
+        for key, value in message.items():
+            num_tokens += len(encoding.encode(value))
+            if key == "name":
+                num_tokens += tokens_per_name
+    num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
+    return num_tokens

--- a/emergent/utils.py
+++ b/emergent/utils.py
@@ -84,13 +84,10 @@ def num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301"):
     try:
         encoding = tiktoken.encoding_for_model(model)
     except KeyError:
-        print("Warning: model not found. Using cl100k_base encoding.")
         encoding = tiktoken.get_encoding("cl100k_base")
     if model == "gpt-3.5-turbo":
-        print("Warning: gpt-3.5-turbo may change over time. Returning num tokens assuming gpt-3.5-turbo-0301.")
         return num_tokens_from_messages(messages, model="gpt-3.5-turbo-0301")
     elif model == "gpt-4":
-        print("Warning: gpt-4 may change over time. Returning num tokens assuming gpt-4-0314.")
         return num_tokens_from_messages(messages, model="gpt-4-0314")
     elif model == "gpt-3.5-turbo-0301":
         tokens_per_message = 4  # every message follows <|start|>{role/name}\n{content}<|end|>\n

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_long_description() -> str:
         return ld_file.read()
 
 
-install_requires = ["openai", "colorama"]
+install_requires = ["openai", "colorama", "tiktoken"]
 
 setup(
     name="emergent",


### PR DESCRIPTION
gpt-3.5-turbo is used to generate summaries, but has half of the token limit of gpt-4. Long prompts that work as user input sometimes break the system.

With this solution, gpt-4 is used instead for instances where token count exceeds 4096 when trying to create a summary. gpt-3.5-turbo is used otherwise.

Not the ideal fix, but it helps. [LangChain would come in handy](https://python.langchain.com/en/latest/modules/chains/index_examples/vector_db_qa.html?highlight=documents), but I didn't want to make huge changes. I only added the `tiktoken` package as a dependency in order to count the tokens in messages.